### PR TITLE
Fix to ensure correct exit codes in local tests

### DIFF
--- a/api/utils/relval_test_submitter.py
+++ b/api/utils/relval_test_submitter.py
@@ -101,6 +101,8 @@ class RelvalTestSubmitter(BaseSubmitter):
         relval.set('status', 'approved')
         relval.add_history('approval', 'succeeded', 'automatic')
         print('SUCCESS: ', time.time()-start_time, ' sec')
+      # Save the exit code and relval status into the database
+      self.store_submission_output(relval, None, exit_code)
       relval_db.save(relval.get_json())
     return relval
 
@@ -140,7 +142,7 @@ class RelvalTestSubmitter(BaseSubmitter):
                 'chmod +x config_test_generate.sh',
                 'export X509_USER_PROXY=$(pwd)/proxy.txt',
                 'echo "$X509_USER_PROXY"',
-                './config_test_generate.sh',
+                './config_test_generate.sh || exit 1',
                 f'rm -rf {workspace_dir}/{prepid}']
     start_time = time.time()
     stdout = ssh.execute_command_new(command)


### PR DESCRIPTION
In the submit_relval_test function, the code checks the value of the exit_code after executing the script. If the exit_code is non-zero (indicating a failure), it will reset some values for relval and set the status to 'new'. Also, if the exit_code is zero (indicating success), it will try to set the optimal parameters in relval. Finally, it saves the exit_code and status of the relval in the database.

     In the perform_local_tests function, the code executes a series of commands via SSH, including running the config_test_generate.sh script. The important point here is the addition of || exit 1 after calling the script. This ensures that if the script fails to run, an exit code of 1 is returned. This means that if the local test fails, a non-zero exit code is returned. The code also reads the output of the SSH command and saves it to the database at regular intervals and at the end of the command execution.