### PR TITLE
Update SMTP mail functionality

### DIFF
--- a/core_lib/utils/emailer.py
+++ b/core_lib/utils/emailer.py
@@ -58,10 +58,11 @@ class Emailer():
         self.message['Cc'] = 'alcauser@cern.ch'
 
         # Send the self.message via our own SMTP server.
-        smtp = smtplib.SMTP('smtp.cern.ch', 587)
+        smtp = smtplib.SMTP('cernmx.cern.ch', 25)
         smtp.starttls()
-        credentials = json.loads(open(Config.get('credentials_file')).read())
-        smtp.login(*list(credentials.values()))
+        # --- Comment mail credentials to use anonymous authentication
+        #credentials = json.loads(open(Config.get('credentials_file')).read())
+        #smtp.login(*list(credentials.values()))
         self.logger.debug('Sending email %s to %s', self.message['Subject'], self.message['To'])
         try:
             smtp.send_message(self.message)
@@ -87,10 +88,11 @@ class Emailer():
         message['Cc'] = 'alcauser@cern.ch'
 
         # Send the message via our own SMTP server.
-        smtp = smtplib.SMTP('smtp.cern.ch', 587)
+        smtp = smtplib.SMTP('cernmx.cern.ch', 25)
         smtp.starttls()
-        credentials = json.loads(open(Config.get('credentials_file')).read())
-        smtp.login(*list(credentials.values()))
+        # --- Comment mail credentials to use anonymous authentication
+        #credentials = json.loads(open(Config.get('credentials_file')).read())
+        #smtp.login(*list(credentials.values()))
         self.logger.debug('Sending email %s to %s', message['Subject'], message['To'])
         smtp.send_message(message)
         smtp.quit()


### PR DESCRIPTION
### PR Description
Trying to address issue https://github.com/cms-AlCaDB/AlCaVal/issues/37

On the same line of the [cmsDbBrowser PR](https://gitlab.cern.ch/cms-ppdweb/cmsDbBrowser/-/merge_requests/198) that addresses the updates of the SMTP services, these are the changes proposed: 
- Changed the server and port as suggested on [OTG0077695](https://cern.service-now.com/service-portal?id=outage&n=OTG0077695)
- Commented out the `smtp.login` lines since the new connection does not require autentication

To do:
- [ ] Possibly add a better SMTP error catching
- [ ] Test this functionality in dev (@pkalbhor I let you handle this)