### PR TITLE
[Dev] Possible fix for the AlCaVal issue #38

### DIFF
--- a/react_frontend/src/features/relvals/reducer.js
+++ b/react_frontend/src/features/relvals/reducer.js
@@ -1,7 +1,7 @@
 
   // Need query params for setting first data request
   var urlParams = new URLSearchParams(window.location.search);
-  const shown = urlParams.get('shown')? urlParams.get('shown'): "111111000000000001011";
+  const shown = urlParams.get('shown')? urlParams.get('shown'): "1111110000000000010010";
   const pageValid =  Number(urlParams.get('page')) >= 0
   const pageSizeValid = Number(urlParams.get('limit')) > 0
   const initPageNumber = pageValid? Number(urlParams.get('page')): 0

--- a/react_frontend/src/features/relvals/useActionsColumn.jsx
+++ b/react_frontend/src/features/relvals/useActionsColumn.jsx
@@ -337,16 +337,17 @@ export const useColumns = (state, role, dispatch) => {
               <li key={workflow.name}>
                 <a target="_blank" title="Open workflow in ReqMgr2" href={`https://cmsweb.cern.ch/reqmgr2/fetch?rid=${workflow.name}`}>{workflow.name}</a>
                 <small style={{color: 'gray'}}> open in:</small> <a target="_blank" title="Open workflow in Stats2" href={`https://cms-pdmv.cern.ch/stats?workflow_name=${workflow.name}`}>Stats2</a>
-                {
-                  workflow.output_datasets.map(dataset =>
-                    <li key={dataset.name}>
-                      <div>
-                        <small style={{color: 'gray'}}>datatier: </small> {dataset.name.split('/').pop()}
-                        <small style={{letterSpacing: "-0.1px"}}><a target="_blank" title="Open dataset in DAS" href={()=>makeDASLink(dataset.name)}>{dataset.name}</a></small>
-                      </div>
-                    </li>
-                  )
-                }
+		if (typeof workflow.output_datasets !== "undefined")
+			{
+	                  workflow.output_datasets.map(dataset =>
+	                    <li key={dataset.name}>
+	                      <div>
+	                        <small style={{color: 'gray'}}>datatier: </small> {dataset.name.split('/').pop()}
+	                        <small style={{letterSpacing: "-0.1px"}}><a target="_blank" title="Open dataset in DAS" href={()=>makeDASLink(dataset.name)}>{dataset.name}</a></small>
+	                      </div>
+	                    </li>
+	                  )
+	                }
                 <br/>
                 <small style={{color: 'gray'}}>Last status: </small> <span style={{color: 'brown'}}>{workflow.status_history[workflow.status_history.length - 1].status}</span>
                 <small style={{color: 'gray'}}> was set </small> { timeSince(new Date(workflow.status_history[workflow.status_history.length - 1].time*1000 ))}


### PR DESCRIPTION
## Description
- The workflows without output datasets break the generic RelVal page
![image](https://github.com/cms-AlCaDB/AlCaVal/assets/57130402/d86f63d3-276a-4ee3-8d29-10af1bf31a87)

   - Fix:  Unchecking the workflow with `111111000000000001011` -> `1111110000000000010010` should fix that 
  
- For specific broken RelVal pages reported in https://github.com/cms-AlCaDB/AlCaVal/issues/38: 
   - The added protection for workflows with undefined output datasets should fix this.  

## Additional Remark
Need to be tested in local and dev first