### PR TITLE
Add `--custom conditions` field in the cmsDriver

### DIFF
--- a/api/model/relval_step.py
+++ b/api/model/relval_step.py
@@ -33,6 +33,7 @@ class RelValStep(ModelBase):
             'conditions': '',
             'customise': '',
             'customise_commands': '',
+            'custom_conditions': '',
             'data': False,
             'datatier': [],
             'era': '',

--- a/application/relvals/relval_forms.py
+++ b/application/relvals/relval_forms.py
@@ -121,6 +121,10 @@ class DriverOptionsForm(CustomForm):
                 render_kw = classDict,
                 label_rkw = label_kw
                 )
+    custom_conditions = SStringField('--custom_conditions',
+                render_kw = classDict,
+                label_rkw = label_kw
+                )
     datatier = SStringField('--datatier',
                 render_kw = classDict,
                 label_rkw = label_kw


### PR DESCRIPTION
### Goal/Reason
To deal with a Full Track Validation Request which required to use either an old HLT menu or a compatible L1T menu customization to run the RelVals on old run but with a new CMSSW release

### Description
- **CMS Talk post**: https://cms-talk.web.cern.ch/t/full-track-validation-hlt-prompt-ecalintercalibconstants-conditions-for-hi-data-taking/29002
- **Release to be used**: `CMSSW_13_2_2`
- **Run to be used**: 368765
- **Driver**: https://alcaval.web.cern.ch/api/relvals/get_cmsdriver/CMSSW_13_2_2__EcalIntercalibConstants-EGamma0Run2023C-00001

- **Error encountered**: https://alcaval.web.cern.ch/relvals/local_test_result/CMSSW_13_2_2__EcalIntercalibConstants-EGamma0Run2023C-00001
![image](https://github.com/cms-AlCaDB/AlCaVal/assets/57130402/ef3798f8-b064-40bd-a4e2-08049b78d0ce)

- **How to fix the Driver to work**: 
```
cmsDriver.py step2 --conditions 132X_dataRun3_HLT_ECAL_w35_2023_v1 --custom_conditions 'L1Menu_Collisions2023_v1_2_0-d1_xml,L1TUtmTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS,,2023-07-03 08:48:29' --data --datatier FEVTDEBUGHLT --era Run3 --eventcontent FEVTDEBUGHLT --filein "filelist:step1_files.txt" --fileout "file:step2.root" --lumiToProcess "step1_lumi_ranges.txt" --nStreams 2 --nThreads 4 --number 10 --process reHLT --python_filename step_2_cfg.py --scenario pp --step L1REPACK:uGT,HLT
```

- **Proposed solution in this PR**: Include the  `--custom_conditions` in Driver and edit the RelVal directly for `L1REPACK,HLT` to `L1REPACK:uGT,HLT`

### PR Validation
The Driver works without issues locally on lxplus. 