### PR TITLE
New token jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,56 @@ GRID user-certificate to be used for accessing cmsweb services
 
 ### Launching the application
 Install docker in case it is not installed in your machine. Follow [Install Docker Engine](https://docs.docker.com/engine/install/) and [Install Docker Compose](https://docs.docker.com/compose/install/).
+
+#### Installing Docker Engine
+##### 1) Install required packages
+```
+sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
+```
+##### 2) Add Docker's official GPG key
+```
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+```
+##### 3) Set up the Docker stable repository
+```
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+```
+
+#### 4) Update the package database
+```
+sudo apt-get update
+```
+
+#### 5) Install Docker
+```
+sudo apt-get install docker-ce
+```
+
+#### 6) Verify Docker installation
+```
+sudo docker --version
+```
+
+### Installing Docker Compose
+
+#### 1) Download Docker Compose
+```
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+```
+Note: Replace 1.29.2 with the latest version of Docker Compose.
+
+#### 2) Apply executable permissions
+```
+sudo chmod +x /usr/local/bin/docker-compose
+```
+#### 3) Verify Docker Compose installation
+```
+docker-compose --version
+```
+
 Then launch application using:
 
 ```docker-compose up app```
 
 Application is accesible at http://localhost:8080 and database can be accessed from http://localhost:8081.
+

--- a/api/controller/jira_controller.py
+++ b/api/controller/jira_controller.py
@@ -49,16 +49,13 @@ class Jira():
         self.credentials_file = credentials_file
         self.host = host
 
-
     def setup_jira_connection(self):
         with open(self.credentials_file) as json_file:
             credentials = json.load(json_file)
 
         options = {'check_update': False}
         self.client  = JIRA(self.host, 
-                            token_auth=(credentials["token"]), # change the old methods to authentication to new using token  
+                            token_auth=(credentials["token"]), 
                             options=options)
         self.logger.debug('Done setting up jira connection')
         return self.client
-
-    

--- a/api/controller/jira_controller.py
+++ b/api/controller/jira_controller.py
@@ -56,7 +56,7 @@ class Jira():
 
         options = {'check_update': False}
         self.client  = JIRA(self.host, 
-                            token_auth=(credentials["token"]), 
+                            token_auth=(credentials["token"]), # change the old methods to authentication to new using token  
                             options=options)
         self.logger.debug('Done setting up jira connection')
         return self.client

--- a/api/controller/jira_controller.py
+++ b/api/controller/jira_controller.py
@@ -26,7 +26,7 @@ class JiraTicketController():
                 'issuetype': {'name': 'Task'},
                 'summary': jira_json['jira_summary'],
                 'description': jira_json['jira_description'],
-                'assignee': {'name': 'tvami'},
+                'assignee': {'name': 'matheus'},
                 'priority': {'name': 'Major'},
                 'components': [{'name' : 'AlCaDB'}] + [{'name': a} for a in components],
                 'labels': [l.strip() for l in jira_json['jira_labels'].split(',')]
@@ -49,14 +49,16 @@ class Jira():
         self.credentials_file = credentials_file
         self.host = host
 
+
     def setup_jira_connection(self):
         with open(self.credentials_file) as json_file:
             credentials = json.load(json_file)
 
         options = {'check_update': False}
         self.client  = JIRA(self.host, 
-                            basic_auth=(credentials['username'], 
-                                        credentials['password']), 
+                            token_auth=(credentials["token"]), 
                             options=options)
         self.logger.debug('Done setting up jira connection')
         return self.client
+
+    


### PR DESCRIPTION
AlCaVal had an error in the ticket creation tab, reporting an authentication problem with Jira.
The new authentication method was recently changed from username and password to a token. An access token was generated at the link https://its.cern.ch/jira/secure/ViewProfile.jspa?name=alcauser following the steps described here: https://its.cern.ch/jira/secure/ViewProfile .jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens.
In the Jira class of the jira_controller.py code we use an API to access Jira with python, after this change the code works normally