### PR TITLE
[DEV] Correction of Jira's PUT to POST method

### DIFF
--- a/api/controller/jira_controller.py
+++ b/api/controller/jira_controller.py
@@ -43,7 +43,7 @@ class JiraTicketController():
         connection.close()
 
 class Jira():
-    def __init__(self, credentials_file, host='http://its.cern.ch/jira'):
+    def __init__(self, credentials_file, host='https://its.cern.ch/jira'):
         self.client = None
         self.logger = logging.getLogger()
         self.credentials_file = credentials_file

--- a/api/jira_api.py
+++ b/api/jira_api.py
@@ -16,7 +16,7 @@ class CreateJiraTicketAPI(APIBase):
     @APIBase.ensure_request_data
     @APIBase.exceptions_to_errors
     @APIBase.ensure_role('manager')
-    def put(self):
+    def post(self):
         """
         Create a ticket with the provided JSON content
         """

--- a/application/tickets/static/js/Jira.js
+++ b/application/tickets/static/js/Jira.js
@@ -46,7 +46,7 @@ function jira_api(data) {
   $('body').addClass('loading');    
   fetch('api/jira/create',
     {
-      method: 'PUT',
+      method: 'POST',
       body: JSON.stringify(data),
       headers: {'Content-Type': 'application/json'}
     }


### PR DESCRIPTION


In the local test log, the output presented two messages that identified the Jira ticket generation error:

alcaval | jira.exceptions.JIRAError: JiraError HTTP URL 405: https://its.cern.ch/jira/rest/api/2/issue
alcaval | [16-Nov-23 13:02:41 UTC][matheus][INFO] [PUT] /api/jira/create 0.1095s 400 (api_base.py:36)

The HTTP 405 error usually indicates "Method Not Allowed", which means that the HTTP method you are trying to use is not allowed for the URL being accessed. In this case, it appears that the PUT method is not allowed in the URL https://its.cern.ch/jira/rest/api/2/issue.

This does not appear to be an authentication error, as normally an authentication error would result in an HTTP 401 or 403 error. Instead, the server is saying that it does not accept the PUT method on that specific URL.

Therefore, the codes from the PUT method to POST were changed and ticket generation was reestablished again.

More information can be found here:
https://docs.atlassian.com/software/jira/docs/api/REST/9.4.8/#api/2/issue-createIssue
