### PR TITLE
[PROD] Use different common prompt GTs for Target HLT and Reference GTs

### DIFF
--- a/api/controller/ticket_controller.py
+++ b/api/controller/ticket_controller.py
@@ -429,7 +429,11 @@ class TicketController(ControllerBase):
             if 'HLT' in cond_tag and step_index == 1:
                 new_step['driver']['conditions'] = ticket.get('hlt_gt{}'.format('_ref' if 'Ref' in cond_tag else ''))
             elif 'HLT' in cond_tag and step_index != 0:
-                new_step['driver']['conditions'] = ticket.get('common_prompt_gt')
+                if 'Ref' in cond_tag:
+                    common_prompt_gt = ticket.get('common_prompt_gt_for_hlt_ref')
+                else:
+                    common_prompt_gt = ticket.get('common_prompt_gt_for_hlt')
+                new_step['driver']['conditions'] = common_prompt_gt
             if 'Prompt' in cond_tag and step_index != 0:
                 new_step['driver']['conditions'] = ticket.get('prompt_gt{}'.format('_ref' if 'Ref' in cond_tag else ''))
             if 'Express' in cond_tag and step_index != 0:

--- a/api/model/ticket.py
+++ b/api/model/ticket.py
@@ -48,8 +48,10 @@ class Ticket(ModelBase):
         'prompt_gt': '',
         # Express GT
         'express_gt': '',
-        # Common Prompt GT
-        'common_prompt_gt': '',
+        # Common Prompt GT for HLT
+        'common_prompt_gt_for_hlt': '',
+        # Common Prompt GT for HLT Ref
+        'common_prompt_gt_for_hlt_ref':'',
         # HLT reference GT
         'hlt_gt_ref': '',
         # Prompt reference GT
@@ -128,7 +130,8 @@ class Ticket(ModelBase):
         'hlt_gt': ModelBase.lambda_check('globaltag'),
         'prompt_gt': ModelBase.lambda_check('globaltag'),
         'express_gt': ModelBase.lambda_check('globaltag'),
-        'common_prompt_gt': ModelBase.lambda_check('globaltag'),
+        'common_prompt_gt_for_hlt': ModelBase.lambda_check('globaltag'),
+        'common_prompt_gt_for_hlt_ref': ModelBase.lambda_check('globaltag'),
         'status': lambda status: status in ('new', 'done'),
         'scram_arch': lambda s: not s or ModelBase.lambda_check('scram_arch')(s),
         'workflow_ids': lambda wf: len(wf) > 0,

--- a/application/tickets/forms.py
+++ b/application/tickets/forms.py
@@ -147,15 +147,20 @@ class TicketForm(FlaskForm):
                 render_kw = classDict | {"id":"hlt_gt", "placeholder":"HLT target global tag"},
                 label_rkw = label_rkw
                 )
-    common_prompt_gt = SStringField('Common Prompt GT',
-                        validators=[GTDataRequired(message="Since you have chosen to use HLT global tag, you are required to provide common prompt global tag, which is to be used in RECO step of workflow")],
-                        render_kw= classDict | {'placeholder': 'Global tag to be used in RECO step of HLT workflow'},
-                        label_rkw = {'class': 'col-form-label-sm'}
-                        )
+    common_prompt_gt_for_hlt = SStringField('Common Prompt GT for target HLT',
+                validators=[GTDataRequired(message="Since you have chosen to use HLT global tag, you are required to provide common prompt global tag for the target HLT, which is to be used in RECO step of workflow")],
+                render_kw=classDict | {'placeholder': 'Global tag to be used in RECO step for target HLT'},
+                label_rkw={'class': 'col-form-label-sm'}
+                )
     hlt_gt_ref = SStringField('Reference HLT GT',
                 validators=[],
                 render_kw = classDict | {"id":"hlt_gt_ref", "placeholder":"HLT reference global tag"},
                 label_rkw = label_rkw
+                )
+    common_prompt_gt_for_hlt_ref = SStringField('Common Prompt GT for reference HLT',
+                validators=[GTDataRequired(message="Since you have chosen to use HLT global tag, you are required to provide common prompt global tag for reference HLT, which is to be used in RECO step of workflow")],
+                render_kw=classDict | {'placeholder': 'Global tag to be used in RECO step for reference HLT'},
+                label_rkw={'class': 'col-form-label-sm'}
                 )
     prompt_gt = SStringField('Target Prompt GT',
                 render_kw = classDict | {'placeholder': 'Prompt target global tag'},

--- a/application/tickets/static/js/TicketEditScript.js
+++ b/application/tickets/static/js/TicketEditScript.js
@@ -19,9 +19,13 @@ function addHelpIcons(){
   var nstreams_help = `${grayHelper} If number of streams is 0, default value will be used</small></td></tr>`
   document.getElementById("n_streams").parentNode.parentNode.insertAdjacentHTML('afterend', nstreams_help)
 
-  var common_gt_help = "Common Prompt GT is usually same as target prompt GT. This field is required if you are using HLT GTs. It will be used in RECO stage of the HLT workflow"
-  common_gt_help = '<span id="commong-gt-help-icon" class="help-icons" data-toggle="popover" data-content="'+common_gt_help+'"><i class="bi bi-question-circle-fill"></i></span>'
-  document.getElementById("common_prompt_gt").insertAdjacentHTML('afterend', common_gt_help)
+  var common_gt_hlt_help = "Common Prompt GT for target HLT is usually the same as the target prompt GT. This field is required when using HLT GTs. It's applied in the RECO stage of the HLTNew workflow."
+  common_gt_hlt_help = '<span class="help-icons" data-toggle="popover" data-content="'+common_gt_hlt_help+'"><i class="bi bi-question-circle-fill"></i></span>'
+  document.getElementById("common_prompt_gt_for_hlt").insertAdjacentHTML('afterend', common_gt_hlt_help)
+
+  var common_gt_hlt_ref_help = "Common Prompt GT for reference HLT is usually the same as the reference prompt GT. This field is required when using HLT GTs. It's applied in the RECO stage of the HLTRef workflow."
+  common_gt_hlt_ref_help = '<span class="help-icons" data-toggle="popover" data-content="'+common_gt_hlt_ref_help+'"><i class="bi bi-question-circle-fill"></i></span>'
+  document.getElementById("common_prompt_gt_for_hlt_ref").insertAdjacentHTML('afterend', common_gt_hlt_ref_help)
 
   var widHelp = `${grayHelper} This is handled by FTV managers, please ignore if you are not the one</small></td></tr>`
   document.getElementById("workflow_ids").parentNode.parentNode.insertAdjacentHTML('afterend', widHelp)


### PR DESCRIPTION
PR to the main branch, same as PR #65 to the dev branch

Currently, the AlCaVal tool provides only one input field for a `Common Prompt GT`  in a ticket. This common prompt GT (usually the target Prompt GT) is then used by both the HLT target relval and HLT reference relval during the reco step of the workflow. However, using the target prompt GT with HLT reference GT may lead to inconsistent/misleading results, as pointed out in [this comment on CMSALCA-261](https://its.cern.ch/jira/browse/CMSALCA-261?focusedId=6337360&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6337360).

This PR aims to introduce two separate fields - `Common Prompt GT for target HLT` and `Common Prompt GT for reference HLT` - in order to use the different prompt GTs for the target and reference relvals. 

**PR Validation**

- Successfully created a ticket with the updated fields in a local instance of the tool
- cmsDriver commands successfully produced with two different prompt GTs for the target and reference relvals
- More details in https://indico.cern.ch/event/1403083/contributions/5897529/attachments/2832947/4949975/L3_report_08_04_24.pdf#page=4 
- Successfully created a ticket in the AlCaVal development tool: https://alcaval-dev.web.cern.ch/tickets?prepid=CMSSW_14_0_4__TkAl-00001 
- cmsDriver commands successfully produced with two different prompt GTs in the AlCaVal dev tool: [HLTNew](https://alcaval-dev.web.cern.ch/api/relvals/get_cmsdriver/CMSSW_14_0_4__TkAl-HLTNew-ExpressPhysicsRun2024A-00001), [HLTRef](https://alcaval-dev.web.cern.ch/api/relvals/get_cmsdriver/CMSSW_14_0_4__TkAl-HLTRef-ExpressPhysicsRun2024A-00001)