### PR TITLE
Update the usage of the newly introduced common prompt GTs

### DIFF
--- a/api/controller/ticket_controller.py
+++ b/api/controller/ticket_controller.py
@@ -95,7 +95,8 @@ class TicketController(ControllerBase):
         editing_info['hlt_gt'] = not_done
         editing_info['prompt_gt'] = not_done
         editing_info['express_gt'] = not_done
-        editing_info['common_prompt_gt'] = not_done
+        editing_info['common_prompt_gt_for_hlt'] = not_done
+        editing_info['common_prompt_gt_for_hlt_ref'] = not_done
         editing_info['hlt_gt_ref'] = not_done
         editing_info['prompt_gt_ref'] = not_done
         editing_info['express_gt_ref'] = not_done
@@ -695,8 +696,10 @@ class TicketController(ControllerBase):
             if gt_ref:
                 gt_list += f' * Reference {cond} GT: [{gt_ref}|{tag_link.format(gt_ref)}]\n'
             if cond == 'HLT':
-                common_gt = ticket.get('common_prompt_gt')
-                gt_list += f' * Common Prompt GT: [{common_gt}|{tag_link.format(common_gt)}]\n'
+                common_gt = ticket.get('common_prompt_gt_for_hlt')
+                gt_list += f' * Common Prompt GT for Target HLT: [{common_gt}|{tag_link.format(common_gt)}]\n'
+                common_gt_ref = ticket.get('common_prompt_gt_for_hlt_ref')
+                gt_list += f' * Common Prompt GT for Reference HLT: [{common_gt_ref}|{tag_link.format(common_gt_ref)}]\n'
             if gt and gt_ref:
                 differ = diff.format(target=gt, ref=gt_ref)
                 gt_list += f' * Difference: [{cond} target vs reference|{differ}]\n'

--- a/application/tickets/forms.py
+++ b/application/tickets/forms.py
@@ -160,7 +160,7 @@ class TicketForm(FlaskForm):
     common_prompt_gt_for_hlt_ref = SStringField('Common Prompt GT for reference HLT',
                 validators=[GTDataRequired(message="Since you have chosen to use HLT global tag, you are required to provide common prompt global tag for reference HLT, which is to be used in RECO step of workflow")],
                 render_kw=classDict | {'placeholder': 'Global tag to be used in RECO step for reference HLT'},
-                label_rkw={'class': 'col-form-label-sm'}
+                label_rkw=label_rkw
                 )
     prompt_gt = SStringField('Target Prompt GT',
                 render_kw = classDict | {'placeholder': 'Prompt target global tag'},


### PR DESCRIPTION
This PR is a follow-up of PR #65.

After the new common prompt GTs were introduced, a few instances were spotted where improvements could be made:

1. The common prompt GT fields get locked after the initial ticket submission, making them non-editable subsequently (See screenshot below). Hence in order to make any changes to these fields, one would have to submit an entirely new ticket.

<img width="650" alt="Screenshot 2024-04-22 at 14 54 58" src="https://github.com/cms-AlCaDB/AlCaVal/assets/92534901/d29e0902-0a61-4d08-848e-a12aae6a602a">

2. The new common prompt GT fields were not passed on to the JIRA tickets. 

**This PR deals with the two above-mentioned issues:**
- It makes the common prompt GTs fields always editable.
- It passes on the new fields to the JIRA ticket

#### PR validation

- Tested using a local instance of the AlCaVal tool. Outcomes:

1. The common prompt GT fields now editable always, as shown below

<img width="650" alt="Screenshot 2024-04-22 at 15 12 12" src="https://github.com/cms-AlCaDB/AlCaVal/assets/92534901/c8c74bec-fb74-45ae-b318-caade631324b">

2. JIRA ticket now includes two different fields for 'Common Prompt GT for Target HLT' and 'Common Prompt GT for Reference HLT' - [CMSALCA-265](https://its.cern.ch/jira/browse/CMSALCA-265)

<img width="548" alt="Screenshot 2024-04-22 at 15 14 37" src="https://github.com/cms-AlCaDB/AlCaVal/assets/92534901/8964d2be-1385-40d2-a667-d8d8b2574263">
